### PR TITLE
Feature/Add help message

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "node scripts/esbuild.js",
     "clean": "rm -rf new-pett-app",
-    "create": "node bin/index.js -lp pnpm",
+    "create": "node bin/index.js --help && node bin/index.js -lp pnpm new-pett-app",
     "test": "run-s build create clean",
     "lint": "prettier --write . --loglevel error",
     "patch": "pnpm run build && pnpm version patch && pnpm publish",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "create-pett-app",
   "author": "Eric Kwoka",
   "license": "MIT",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Preact, Esbuild, Tailwindcss, Typescript",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -24,18 +24,20 @@
   },
   "dependencies": {
     "command-line-args": "^5.2.1",
+    "command-line-usage": "^6.1.3",
     "draftlog": "^1.0.13",
     "ncp": "^2.0.0"
   },
   "devDependencies": {
-    "ts-node": "^10.9.1",
     "@types/command-line-args": "^5.2.0",
+    "@types/command-line-usage": "^5.0.2",
     "@types/ncp": "^2.0.5",
     "@types/node": "^18.0.6",
     "esbuild": "^0.14.49",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
     "prettier-plugin-tailwindcss": "^0.1.12",
+    "ts-node": "^10.9.1",
     "typescript": "^4.7.4"
   },
   "prettier": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,55 @@
+export const optionDefinitions = [
+  {
+    name: 'dir',
+    description: 'The directory in which your project is created',
+    type: String,
+    defaultOption: true,
+    defaultValue: undefined,
+  },
+  {
+    name: 'help',
+    alias: 'h',
+    description: 'Shows this help screen',
+    type: Boolean,
+    defaultValue: false,
+  },
+  {
+    name: 'packagemanager',
+    alias: 'p',
+    description: 'Which package manager to use',
+    typeLabel: 'pnpm | {underline npm} | yarn | bun',
+    type: (pm: string) =>
+      ['pnpm', 'npm', 'yarn', 'bun'].includes(pm) ? pm : 'npm',
+    defaultValue: 'npm',
+  },
+  {
+    name: 'typescript',
+    alias: 'T',
+    description: 'Include typescript in the project',
+    typeLabel: '{underline true} | false',
+    type: (T: string) => !(T === 'false'),
+    defaultValue: 'true',
+  },
+  {
+    name: 'lint',
+    alias: 'l',
+    description: 'Include eslint and prettier in the project',
+    typeLabel: 'true | {underline false}',
+    type: Boolean,
+    defaultValue: false,
+  },
+  {
+    name: 'test',
+    alias: 't',
+    type: Boolean,
+    defaultValue: false,
+    description: 'Feature Not Implemented',
+  },
+  {
+    name: 'netlify',
+    alias: 'n',
+    type: Boolean,
+    defaultValue: false,
+    description: 'Feature Not Implemented',
+  },
+];

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,8 @@ const optionDefinitions = [
     name: 'help',
     alias: 'h',
     description: 'Shows this help screen',
-    type: (T: string) => !(T === 'false'),
-    defaultValue: 'false',
+    type: Boolean,
+    defaultValue: false,
   },
   {
     name: 'packagemanager',

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,8 +69,7 @@ const {
 } = commandLineArgs(optionDefinitions);
 
 if (help || !dir) {
-  // Slice so that the "dir" option isn't displayed in the help
-  showHelp(optionDefinitions.slice(1));
+  showHelp(optionDefinitions.filter(it => !it.defaultOption));
   exit(0);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,10 +29,7 @@ const {
   netlify,
 } = commandLineArgs(optionDefinitions);
 
-if (help || !dir) {
-  showHelp(optionDefinitions.filter(it => !it.defaultOption));
-  exit(0);
-}
+if (help || !dir) showHelp(optionDefinitions);
 
 const updateStatus = intervalProgress('Building New PETT App...');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,53 +14,10 @@ import {
   intervalProgress,
   showHelp,
 } from './utils/index.js';
+import { optionDefinitions } from './config.js';
 DraftLog(console);
 
 console.time('App Built');
-
-const optionDefinitions = [
-  {
-    name: 'dir',
-    description: 'The directory in which your project is created',
-    type: String,
-    defaultOption: true,
-    defaultValue: undefined,
-  },
-  {
-    name: 'help',
-    alias: 'h',
-    description: 'Shows this help screen',
-    type: Boolean,
-    defaultValue: false,
-  },
-  {
-    name: 'packagemanager',
-    alias: 'p',
-    description: 'Which package manager to use',
-    typeLabel: 'pnpm | {underline npm} | yarn | bun',
-    type: (pm: string) =>
-      ['pnpm', 'npm', 'yarn', 'bun'].includes(pm) ? pm : 'npm',
-    defaultValue: 'npm',
-  },
-  {
-    name: 'typescript',
-    alias: 'T',
-    description: 'Include typescript in the project',
-    typeLabel: '{underline true} | false',
-    type: (T: string) => !(T === 'false'),
-    defaultValue: 'true',
-  },
-  {
-    name: 'lint',
-    alias: 'l',
-    description: 'Include eslint and prettier in the project',
-    typeLabel: 'true | {underline false}',
-    type: Boolean,
-    defaultValue: false,
-  },
-  { name: 'test', alias: 't', type: Boolean, defaultValue: false },
-  { name: 'netlify', alias: 'n', type: Boolean, defaultValue: false },
-];
 
 const {
   dir,

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,14 @@ const optionDefinitions = [
     type: (T: string) => !(T === 'false'),
     defaultValue: 'true',
   },
-  { name: 'lint', alias: 'l', description: 'Include eslint and prettier in the project', typeLabel: 'true | {underline false}', type: Boolean, defaultValue: false },
+  {
+    name: 'lint',
+    alias: 'l',
+    description: 'Include eslint and prettier in the project',
+    typeLabel: 'true | {underline false}',
+    type: Boolean,
+    defaultValue: false,
+  },
   { name: 'test', alias: 't', type: Boolean, defaultValue: false },
   { name: 'netlify', alias: 'n', type: Boolean, defaultValue: false },
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,18 @@
 import { join } from 'node:path';
 import commandLineArgs from 'command-line-args';
 import DraftLog from 'draftlog';
-import { execShellCommand, intervalProgress } from './utils/index.js';
-import { inCYAN, inGREEN } from './utils/colors.js';
 import { buildPackage } from './packages/buildpackage.js';
 import { install } from './install.js';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { buildBundles } from './packages/buildBundles.js';
-import { showHelp } from './utils/help.js';
 import { exit } from 'node:process';
+import {
+  execShellCommand,
+  inCYAN,
+  inGREEN,
+  intervalProgress,
+  showHelp,
+} from './utils/index.js';
 DraftLog(console);
 
 console.time('App Built');

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import { buildPackage } from './packages/buildpackage.js';
 import { install } from './install.js';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { buildBundles } from './packages/buildBundles.js';
+import { showHelp } from './utils/help.js';
+import { exit } from 'node:process';
 DraftLog(console);
 
 console.time('App Built');
@@ -15,13 +17,23 @@ console.time('App Built');
 const optionDefinitions = [
   {
     name: 'dir',
+    description: 'The directory in which your project is created',
     type: String,
     defaultOption: true,
-    defaultValue: 'new-pett-app',
+    defaultValue: undefined,
+  },
+  {
+    name: 'help',
+    alias: 'h',
+    description: 'Shows this help screen',
+    type: (T: string) => !(T === 'false'),
+    defaultValue: 'false',
   },
   {
     name: 'packagemanager',
     alias: 'p',
+    description: 'Which package manager to use',
+    typeLabel: 'pnpm | {underline npm} | yarn | bun',
     type: (pm: string) =>
       ['pnpm', 'npm', 'yarn', 'bun'].includes(pm) ? pm : 'npm',
     defaultValue: 'npm',
@@ -29,22 +41,31 @@ const optionDefinitions = [
   {
     name: 'typescript',
     alias: 'T',
+    description: 'Include typescript in the project',
+    typeLabel: '{underline true} | false',
     type: (T: string) => !(T === 'false'),
     defaultValue: 'true',
   },
-  { name: 'lint', alias: 'l', type: Boolean, defaultValue: false },
+  { name: 'lint', alias: 'l', description: 'Include eslint and prettier in the project', typeLabel: 'true | {underline false}', type: Boolean, defaultValue: false },
   { name: 'test', alias: 't', type: Boolean, defaultValue: false },
   { name: 'netlify', alias: 'n', type: Boolean, defaultValue: false },
 ];
 
 const {
   dir,
+  help,
   packagemanager: packageManager,
   typescript,
   lint,
   test,
   netlify,
 } = commandLineArgs(optionDefinitions);
+
+if (help || !dir) {
+  // Slice so that the "dir" option isn't displayed in the help
+  showHelp(optionDefinitions.slice(1));
+  exit(0);
+}
 
 const updateStatus = intervalProgress('Building New PETT App...');
 

--- a/src/utils/help.ts
+++ b/src/utils/help.ts
@@ -1,5 +1,6 @@
 import { OptionDefinition } from 'command-line-args';
 import commandLineUsage from 'command-line-usage';
+import { exit } from 'node:process';
 
 export function showHelp(options: OptionDefinition[]) {
   const help = commandLineUsage([
@@ -17,9 +18,11 @@ export function showHelp(options: OptionDefinition[]) {
     },
     {
       header: 'Options',
-      optionList: options,
+      optionList: options.filter((it) => !it.defaultOption),
     },
   ]);
 
   console.log(help);
+
+  exit(0);
 }

--- a/src/utils/help.ts
+++ b/src/utils/help.ts
@@ -12,8 +12,8 @@ export function showHelp(options: OptionDefinition[]) {
     {
       header: 'Usage',
       content: [
-        '$ npx create-pett-app [...options] <directory>',
-        '$ npx create-pett-app --help',
+        '$ npm init pett-app [...options] <directory>',
+        '$ npm init pett-app --help',
       ],
     },
     {

--- a/src/utils/help.ts
+++ b/src/utils/help.ts
@@ -1,0 +1,24 @@
+import { OptionDefinition } from 'command-line-args';
+import commandLineUsage from 'command-line-usage';
+
+export function showHelp(options: OptionDefinition[]) {
+  const help = commandLineUsage([
+    {
+      header: 'create-PETT-app',
+      content: 'Creates a new PETT (Preact, Eslint, Typescript, TailwindCSS) application.',
+    },
+    {
+      header: 'Usage',
+      content: [
+        '$ npx create-pett-app [...options] <directory>',
+	'$ npx create-pett-app --help',
+      ],
+    },
+    {
+      header: 'Options',
+      optionList: options,
+    }
+  ]);
+
+  console.log(help);
+}

--- a/src/utils/help.ts
+++ b/src/utils/help.ts
@@ -5,19 +5,20 @@ export function showHelp(options: OptionDefinition[]) {
   const help = commandLineUsage([
     {
       header: 'create-PETT-app',
-      content: 'Creates a new PETT (Preact, Eslint, Typescript, TailwindCSS) application.',
+      content:
+        'Creates a new PETT (Preact, Eslint, Typescript, TailwindCSS) application.',
     },
     {
       header: 'Usage',
       content: [
         '$ npx create-pett-app [...options] <directory>',
-	'$ npx create-pett-app --help',
+        '$ npx create-pett-app --help',
       ],
     },
     {
       header: 'Options',
       optionList: options,
-    }
+    },
   ]);
 
   console.log(help);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,8 @@
-export { RED, GREEN, CYAN } from './colors.js';
+export { RED, inRED, GREEN, inGREEN, CYAN, inCYAN, RESET } from './colors.js';
+export { CONFIG } from './config.js';
 export { execShellCommand } from './execShellCommand.js';
+export { showHelp } from './help.js';
+export { originDirectory } from './originDirectory.js';
+export { patchObjects } from './patchObjects.js';
 export { progressDraft, intervalProgress } from './progressDraft.js';
+export type { AnyObject } from './patchObjects.js';


### PR DESCRIPTION
Solves #1 

Creates a new --help option, uses [command-line-usage](https://github.com/75lb/command-line-usage) to generate a command line usage screen, as recommended by the command-line-args authors.